### PR TITLE
:ox: Updating to current version of oxmysql (2.6.0)

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -15,7 +15,7 @@ end
 local function loadHouseData()
     local HouseGarages = {}
     local Houses = {}
-    local result = MySQL.Sync.fetchAll('SELECT * FROM houselocations')
+    local result = MySQL.query.await('SELECT * FROM houselocations')
     if result[1] ~= nil then
         for k, v in pairs(result) do
             local owned = false
@@ -82,7 +82,7 @@ end)
 exports['qbr-core']:CreateCallback("qb-multicharacter:server:setupCharacters", function(source, cb)
     local license = exports['qbr-core']:GetIdentifier(source, 'license')
     local plyChars = {}
-    MySQL.Async.fetchAll('SELECT * FROM players WHERE license = @license', {['@license'] = license}, function(result)
+    MySQL.query('SELECT * FROM players WHERE license = @license', {['@license'] = license}, function(result)
         for i = 1, (#result), 1 do
             result[i].charinfo = json.decode(result[i].charinfo)
             result[i].money = json.decode(result[i].money)
@@ -112,7 +112,7 @@ exports['qbr-core']:CreateCallback("qb-multicharacter:server:GetNumberOfCharacte
 end)
 
 exports['qbr-core']:CreateCallback("qbr-multicharacter:server:getSkin", function(source, cb, cid)
-    MySQL.Async.fetchAll('SELECT * FROM playerskins WHERE citizenid = ? AND active = ?', {cid, 1}, function(result)
+    MySQL.query('SELECT * FROM playerskins WHERE citizenid = ? AND active = ?', {cid, 1}, function(result)
         result[1].skin = json.decode(result[1].skin)
         result[1].clothes = json.decode(result[1].clothes)
         cb(result[1])


### PR DESCRIPTION
Requires: oxmysql update 2.6.0
----------------------------------------------------------------------------------------------------------------------------------------------------------------
Issue: Current mysql calls are outdated. 

Fix: Update the oxmysql calls to current.

Expected result: We can now to update to the newest version of oxmysql and have the resource interact without errors. Saving and loading should work as normal. 